### PR TITLE
Fix for widget refresh in 6.9.0+, add configurable refresh delay

### DIFF
--- a/src/corsairpsu/usr/local/emhttp/plugins/corsairpsu/CorsairPSUSettings.page
+++ b/src/corsairpsu/usr/local/emhttp/plugins/corsairpsu/CorsairPSUSettings.page
@@ -3,10 +3,13 @@ Icon="corsairpsu.png"
 Title="Corsair PSU"
 ---
 <?php
-$corsairpsu_cfg 	= parse_plugin_cfg("corsairpsu",true);
-$corsairpsu_type 	= isset($corsairpsu_cfg['TYPE']) ? $corsairpsu_cfg['TYPE'] : "corsairmi";
-$corsairpsu_tty 	= isset($corsairpsu_cfg['TTY']) ? $corsairpsu_cfg['TTY'] : "/dev/ttyUSB0";
+$corsairpsu_cfg 			= parse_plugin_cfg("corsairpsu",true);
+$corsairpsu_type			= isset($corsairpsu_cfg['TYPE']) ? $corsairpsu_cfg['TYPE'] : "corsairmi";
+$corsairpsu_tty				= isset($corsairpsu_cfg['TTY']) ? $corsairpsu_cfg['TTY'] : "/dev/ttyUSB0";
+$corsairpsu_uirefresh 		= isset($corsairpsu_cfg['UIREFRESH']) ? $corsairpsu_cfg['UIREFRESH'] : "/dev/ttyUSB0";
+$corsairpsu_uirefreshint 	= isset($corsairpsu_cfg['UIREFRESHINT']) ? $corsairpsu_cfg['UIREFRESHINT'] : "2000";
 ?>
+
 <b><font style='color:cyan;'>Corsair PSU Statistics</font></b>
 <form markdown="1" method="POST" action="/update.php" target="progressFrame">
 <input type="hidden" name="#file" value="corsairpsu/corsairpsu.cfg" />
@@ -23,11 +26,16 @@ Serial Device (Only needed for AXi PSU's):
 > Please note that AXi PSU's use a different method to communicate and therefore some additional configuration may be required. <br />
 > Please visit <a href="https://forums.unraid.net/topic/86715-corsair-psu-statistics-inteligent-psus-fma965s-fork/">https://forums.unraid.net/topic/86715-corsair-psu-statistics-inteligent-psus-fma965s-fork/</a> for further information.
 
+UI Automatic Refresh / Interval (Milliseconds):
+: <select id="UIREFRESH" name="UIREFRESH" size="1">
+  <?=mk_option($corsairpsu_uirefresh, "0", "No");?>
+  <?=mk_option($corsairpsu_uirefresh, "1", "Yes");?>
+  </select>
+  <input type="text" name="UIREFRESHINT" class="narrow" maxlength="5" value="<?=$corsairpsu_uirefreshint;?>" placeholder="1000">
 
  <input id="DEFAULT" class="stopped" type="submit" value="Default" onClick="resetDATA(this.form)">
 : <input id="btnApply" type="submit" value="Apply"><input type="button" value="Done" onClick="done()">
 </form>
-
 
 <script type="text/javascript">
 function resetDATA(form) {

--- a/src/corsairpsu/usr/local/emhttp/plugins/corsairpsu/status.page
+++ b/src/corsairpsu/usr/local/emhttp/plugins/corsairpsu/status.page
@@ -36,7 +36,6 @@ Icon="ups"
                 </div>
                 <i class="fa fa-fw chevron mt0" id="dash_corsairpsu_toggle" onclick="toggleChevron('dash_corsairpsu_toggle',0)"></i>
                 <a href="/Settings/CorsairPSUSettings" id="dash_corsairpsu_settings" title="Go to Corsair PSU settings"><i class="fa fa-fw fa-cog chevron mt0"></i></a>
-                
             </td>
             <td></td>
         </tr>
@@ -88,18 +87,18 @@ Icon="ups"
 </table>
 <script>
 const corsairpsu_status = () => {
- $.getJSON("/plugins/corsairpsu/status.php", (data) => {
-  if(data) {
-    $.each(data, function (key, data) {
-        $(".corsair-"+key).html(data);
-    })
-  }
-<?if ($update):?>
-  setTimeout(corsairpsu_status, <?=max(abs($display["refresh"]),2000)?>);
-<?endif;?>
- });
+    $.getJSON("/plugins/corsairpsu/status.php", (data) => {
+        if (data) {
+         $.each(data, function (key, data) {
+             $(".corsair-" + key).html(data);
+         })
+        }
+    });
 };
 $(corsairpsu_status);
+if (<?=$corsairpsu_cfg['UIREFRESH'];?>) {
+    setInterval(corsairpsu_status, <?=max(abs($display['refresh']), $corsairpsu_cfg['UIREFRESHINT']);?>);
+}
 
 $(function() {
   // append data from the table into the correct one


### PR DESCRIPTION
- Fixes dashboard widget not automatically refreshing under UnRAID 6.9.0+ installs
- Implements two settings:  UIREFRESH for enabling/disabling refresh and UIREFRESHINT for specifying the delay for refreshing the widget (default is 2 seconds)