### PR TITLE
Add estimated efficiency

### DIFF
--- a/src/corsairpsu/usr/local/emhttp/plugins/corsairpsu/status.page
+++ b/src/corsairpsu/usr/local/emhttp/plugins/corsairpsu/status.page
@@ -9,7 +9,6 @@ Icon="ups"
         echo '.corsair-temp-rm { display:none; }';
     } else {    
         echo '.corsair-uptime-rm td { padding-bottom: 20px !important;}';
-        echo '.corsair-efficiency-ax { display:none; }';
         echo '.corsair-temp-ax { display:none; }';
     }
 ?>
@@ -79,8 +78,9 @@ Icon="ups"
         </tr>
         <tr class="corsair-efficiency-ax">
             <td></td>
-            <td>Efficiency</td>
-            <td colspan="2"><span class="corsair-efficiency"></span>%</td>
+            <td>Efficiency / Supply</td>
+            <td><span class="corsair-efficiency"></span>% (<span class="corsair-input_power"></span>W)</span></td>
+            <td><span class="corsair-input_voltage"></span>V</td>
             <td></td>
         </tr>
     </tbody>

--- a/src/corsairpsu/usr/local/emhttp/plugins/corsairpsu/status.php
+++ b/src/corsairpsu/usr/local/emhttp/plugins/corsairpsu/status.php
@@ -24,7 +24,58 @@ if (!isset($data))
 if ($settings["TYPE"] == "corsairmi") {
 	$capacity = filter_var($data['product'], FILTER_SANITIZE_NUMBER_INT);
 	$load     = round($data['total watts'] / $capacity * 100);
-	
+
+	$output_power = round($data['total watts']);
+	$input_voltage = round($data['supply volts']);
+
+	# Table of Corsair power estimation of each model
+	switch ($data['product']) {
+		case "RM650i":
+			$fpowin115 = 0.00017323493381072683 * $output_power * $output_power + 1.0047044721686030 * $output_power + 12.376592422281606;
+			$fpowin230 = 0.00012413136310310370 * $output_power * $output_power + 1.0284317478987164 * $output_power + 9.465259079360674;
+			break;
+		case "RM750i":
+			$fpowin115 = 0.00015013694263596336 * $output_power * $output_power + 1.0047044721686027 * $output_power + 14.280683564171110;
+			$fpowin230 = 0.00010460621468919797 * $output_power * $output_power + 1.0173089573727216 * $output_power + 11.495900706372142;
+			break;
+		case "RM850i":
+			$fpowin115 = 0.00012280002467981107 * $output_power * $output_power + 1.0159421430340847 * $output_power + 13.555472968718759;
+			$fpowin230 = 0.00008816054254801031 * $output_power * $output_power + 1.0234738318592156 * $output_power + 10.832902491655597;
+			break;
+		case "RM1000i":
+			$fpowin115 = 0.00010018433053123574 * $output_power * $output_power + 1.0272313660072225 * $output_power + 14.092187353321624;
+			$fpowin230 = 0.00008600634771656125 * $output_power * $output_power + 1.0289245073649413 * $output_power + 13.701515390258626;
+			break;
+		case "HX750i":
+			$fpowin115 = 0.00013153276902318052 * $output_power * $output_power + 1.0118732314945875 * $output_power + 9.783796618886313;
+			$fpowin230 = 0.00009268856467314546 * $output_power * $output_power + 1.0183515407387007 * $output_power + 8.279822175342481;
+			break;
+		case "HX850i":
+			$fpowin115 = 0.00011552923724840388 * $output_power * $output_power + 1.0111311876704099 * $output_power + 12.015296651918918;
+			$fpowin230 = 0.00008126644224872423 * $output_power * $output_power + 1.0176256272095185 * $output_power + 10.290640442373850;
+			break;
+		case "HX1000i":
+			$fpowin115 = 0.00009486097544171090 * $output_power * $output_power + 1.0170509865269720 * $output_power + 11.619826520447452;
+			$fpowin230 = 0.00009649987544008507 * $output_power * $output_power + 1.0018241767296636 * $output_power + 12.759957859756842;
+			break;
+		case "HX1200i":
+			$fpowin115 = 0.00006244705156199815 * $output_power * $output_power + 1.0234738310580973 * $output_power + 15.293509559389241;
+			$fpowin230 = 0.00005941317979435096 * $output_power * $output_power + 1.0023670927127724 * $output_power + 15.886126793547152;
+			break;
+		default:
+			$fpowin115 = 0;
+			$fpowin230 = 0;
+	}
+
+	# If the model is not listed above show 0
+	if ($fpowin230 == 0) {
+		$est_input_power = 0;
+		$efficiency = 0;
+	} else {
+		$est_input_power = $fpowin115 + ($fpowin230 - $fpowin115) / 115 * ($input_voltage - 115);
+		$efficiency = round($output_power * 100 / $est_input_power);
+	}
+
 	$output0_load     = round($data['output0 watts'] / $capacity * 100);
 	$output1_load     = round($data['output1 watts'] / $capacity * 100);
 	$output2_load     = round($data['output2 watts'] / $capacity * 100);
@@ -58,7 +109,9 @@ if ($settings["TYPE"] == "corsairmi") {
 		'uptime_raw' => substr($data['uptime'], 0, strpos($data['uptime'], ' ')),
 		'poweredon' => $poweredon[1],
 		'poweredon_raw' => substr($data['powered'], 0, strpos($data['powered'], ' ')),
-		'efficiency' => "Not Supported"
+		'input_voltage' => round($input_voltage),
+		'input_power' => round($est_input_power),
+		'efficiency' => floatval($efficiency)
 	);	
 } else {
 	$capacity = filter_var($data["PSU type"], FILTER_SANITIZE_NUMBER_INT);


### PR DESCRIPTION
Calculate the efficiency of the PSU using Corsair estimated curves. Each PSU have different values, they are calculated on the switch sentence.
In case the PSU is not listed it will show 0% (0W).